### PR TITLE
Fix race condition in MemoryCache.Get by removing unsynchronized lastAccess write

### DIFF
--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -138,9 +138,6 @@ func (m *MemoryCache) Get(key string) (interface{}, bool) {
 		return nil, false
 	}
 
-	// Update last access time
-	entry.lastAccess = time.Now()
-
 	m.hits.Add(1)
 	return entry.value, true
 }


### PR DESCRIPTION


## Test Plan
```bash
go test -race -run TestMemoryCache/concurrent_access ./internal/github/ -v 2>&1
```