### PR TITLE
(feat) Prune stale remote-tracking refs during land cleanup

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1550,3 +1550,19 @@ func (r *Repository) DeleteLocalBranch(branch string) error {
 		Msg("Deleted local branch")
 	return nil
 }
+
+// PruneRemoteRefs removes stale remote-tracking references for branches that
+// no longer exist on the remote (e.g. after GitHub auto-deletes a merged branch).
+func (r *Repository) PruneRemoteRefs() error {
+	cmd := exec.Command("git", "remote", "prune", "origin")
+	cmd.Dir = r.path
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to prune remote references: %w\nOutput: %s",
+			err, string(output))
+	}
+
+	logger.Debug().Msg("Pruned stale remote-tracking references")
+	return nil
+}

--- a/internal/land/cleanup.go
+++ b/internal/land/cleanup.go
@@ -15,6 +15,7 @@ var (
 type CleanupRepo interface {
 	CheckoutBranch(branch string) error
 	PullOrigin(branch string) error
+	PruneRemoteRefs() error
 	GetBranchSHA(branch string) (string, error)
 	DeleteLocalBranch(branch string) error
 }
@@ -23,6 +24,7 @@ type CleanupRepo interface {
 type CleanupResult struct {
 	CheckedOut       bool
 	Pulled           bool
+	RemotePruned     bool
 	BranchDeleted    bool
 	DeletedBranchSHA string
 	Warnings         []string
@@ -63,6 +65,13 @@ func (c *PostMergeCleanup) Execute(defaultBranch, featureBranch string, noDelete
 			fmt.Sprintf("Failed to pull latest on %s: %v — run 'git pull origin %s' manually", defaultBranch, err, defaultBranch))
 	} else {
 		result.Pulled = true
+	}
+
+	if err := c.repo.PruneRemoteRefs(); err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Failed to prune remote references: %v — run 'git remote prune origin' manually", err))
+	} else {
+		result.RemotePruned = true
 	}
 
 	if noDelete {

--- a/internal/land/cleanup_test.go
+++ b/internal/land/cleanup_test.go
@@ -8,11 +8,13 @@ import (
 type mockCleanupRepo struct {
 	checkoutErr       error
 	pullErr           error
+	pruneErr          error
 	branchSHA         string
 	branchSHAErr      error
 	deleteBranchErr   error
 	checkoutCalls     []string
 	pullCalls         []string
+	pruneCalls        int
 	branchSHACalls    []string
 	deleteBranchCalls []string
 }
@@ -25,6 +27,11 @@ func (m *mockCleanupRepo) CheckoutBranch(branch string) error {
 func (m *mockCleanupRepo) PullOrigin(branch string) error {
 	m.pullCalls = append(m.pullCalls, branch)
 	return m.pullErr
+}
+
+func (m *mockCleanupRepo) PruneRemoteRefs() error {
+	m.pruneCalls++
+	return m.pruneErr
 }
 
 func (m *mockCleanupRepo) GetBranchSHA(branch string) (string, error) {
@@ -52,6 +59,9 @@ func TestPostMergeCleanup_Execute_HappyPath(t *testing.T) {
 	if !result.Pulled {
 		t.Error("expected Pulled to be true")
 	}
+	if !result.RemotePruned {
+		t.Error("expected RemotePruned to be true")
+	}
 	if !result.BranchDeleted {
 		t.Error("expected BranchDeleted to be true")
 	}
@@ -67,6 +77,9 @@ func TestPostMergeCleanup_Execute_HappyPath(t *testing.T) {
 	}
 	if len(mock.pullCalls) != 1 || mock.pullCalls[0] != "main" {
 		t.Errorf("expected pull called with 'main', got %v", mock.pullCalls)
+	}
+	if mock.pruneCalls != 1 {
+		t.Errorf("expected prune called once, got %d", mock.pruneCalls)
 	}
 	if len(mock.deleteBranchCalls) != 1 || mock.deleteBranchCalls[0] != "feature/auth" {
 		t.Errorf("expected delete called with 'feature/auth', got %v", mock.deleteBranchCalls)
@@ -88,11 +101,17 @@ func TestPostMergeCleanup_Execute_NoDelete(t *testing.T) {
 	if !result.Pulled {
 		t.Error("expected Pulled to be true")
 	}
+	if !result.RemotePruned {
+		t.Error("expected RemotePruned to be true even when noDelete is true")
+	}
 	if result.BranchDeleted {
 		t.Error("expected BranchDeleted to be false when noDelete is true")
 	}
 	if result.DeletedBranchSHA != "" {
 		t.Errorf("expected empty DeletedBranchSHA, got %s", result.DeletedBranchSHA)
+	}
+	if mock.pruneCalls != 1 {
+		t.Errorf("expected prune called once even with noDelete, got %d", mock.pruneCalls)
 	}
 	if len(mock.deleteBranchCalls) != 0 {
 		t.Error("expected delete not to be called when noDelete is true")
@@ -131,6 +150,9 @@ func TestPostMergeCleanup_Execute_CheckoutFailure(t *testing.T) {
 	if len(mock.pullCalls) != 0 {
 		t.Error("pull should not be called after checkout failure")
 	}
+	if mock.pruneCalls != 0 {
+		t.Error("prune should not be called after checkout failure")
+	}
 	if len(mock.deleteBranchCalls) != 0 {
 		t.Error("delete should not be called after checkout failure")
 	}
@@ -156,6 +178,35 @@ func TestPostMergeCleanup_Execute_PullFailure(t *testing.T) {
 	}
 	if !result.BranchDeleted {
 		t.Error("expected BranchDeleted to be true — pull failure should not block deletion")
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
+	}
+}
+
+func TestPostMergeCleanup_Execute_PruneFailure(t *testing.T) {
+	mock := &mockCleanupRepo{
+		pruneErr:  errors.New("network timeout"),
+		branchSHA: "abc1234",
+	}
+	cleanup := NewPostMergeCleanup(mock)
+
+	result, err := cleanup.Execute("main", "feature/auth", false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.CheckedOut {
+		t.Error("expected CheckedOut to be true")
+	}
+	if !result.Pulled {
+		t.Error("expected Pulled to be true")
+	}
+	if result.RemotePruned {
+		t.Error("expected RemotePruned to be false")
+	}
+	if !result.BranchDeleted {
+		t.Error("expected BranchDeleted to be true — prune failure should not block deletion")
 	}
 	if len(result.Warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d: %v", len(result.Warnings), result.Warnings)
@@ -222,7 +273,7 @@ func TestPostMergeCleanup_Execute_AllFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.CheckedOut || result.Pulled || result.BranchDeleted {
+	if result.CheckedOut || result.Pulled || result.RemotePruned || result.BranchDeleted {
 		t.Error("nothing should succeed when checkout fails")
 	}
 	if len(result.Warnings) != 1 {

--- a/internal/land/output.go
+++ b/internal/land/output.go
@@ -131,6 +131,11 @@ func (o *OutputStyle) PrintCheckout(branch string) {
 	o.PrintStep("✓", fmt.Sprintf("Switched to %s, pulled latest", branch))
 }
 
+// PrintRemotePruned prints the remote refs prune step.
+func (o *OutputStyle) PrintRemotePruned() {
+	o.PrintStep("✓", "Pruned stale remote-tracking references")
+}
+
 // PrintBranchDeleted prints the branch deletion step with a restore command.
 func (o *OutputStyle) PrintBranchDeleted(branch, sha string) {
 	shortSHA := truncateSHA(sha)

--- a/internal/land/workflow.go
+++ b/internal/land/workflow.go
@@ -218,6 +218,9 @@ func (w *LandWorkflow) printCleanupResult(result *CleanupResult, defaultBranch, 
 	if result.CheckedOut && result.Pulled {
 		w.output.PrintCheckout(defaultBranch)
 	}
+	if result.RemotePruned {
+		w.output.PrintRemotePruned()
+	}
 	if result.BranchDeleted {
 		w.output.PrintBranchDeleted(featureBranch, result.DeletedBranchSHA)
 	}

--- a/internal/land/workflow_test.go
+++ b/internal/land/workflow_test.go
@@ -54,6 +54,10 @@ func (m *mockWorkflowRepo) PullOrigin(_ string) error {
 	return m.pullErr
 }
 
+func (m *mockWorkflowRepo) PruneRemoteRefs() error {
+	return nil
+}
+
 func (m *mockWorkflowRepo) GetBranchSHA(_ string) (string, error) {
 	return m.branchSHA, m.branchSHAErr
 }


### PR DESCRIPTION
After a successful merge, GitHub typically auto-deletes the remote branch,
leaving a stale origin/<branch> ref locally. The cleanup step now runs
`git remote prune origin` to remove these automatically.