### PR TITLE
Resolve file discovery from repo root, not cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ So we've come up with a "simple as a rock" (is that a thing? 🤔) solution to b
 
 `gh-arc` can be configured using either JSON or YAML configuration files. The extension looks for configuration files in the following locations (in order of precedence):
 
-1. Current directory: `./.arc.json`, `./.arc.yaml`, or `./.arc.yml`
+1. Repository root: `./.arc.json`, `./.arc.yaml`, or `./.arc.yml` (resolved from the git repository root, so it works from any subdirectory)
 2. User config: `~/.config/gh-arc/.arc.json`, `~/.config/gh-arc/.arc.yaml`, or `~/.config/gh-arc/.arc.yml`
 3. System-wide: `/etc/gh-arc/.arc.json`, `/etc/gh-arc/.arc.yaml`, or `/etc/gh-arc/.arc.yml`
 

--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -647,7 +647,7 @@ Uses Viper for flexible configuration management.
 
 1. **Command-line flags** (highest priority)
 2. **Environment variables** (`GHARC_*` prefix)
-3. **Config files** in current directory
+3. **Config files** in repository root directory (resolved via `git.FindRepositoryRoot`, works from any subdirectory)
 4. **Config files** in user config directory (`~/.config/gh-arc/`)
 5. **Config files** in system directory (`/etc/gh-arc/`)
 6. **Default values** (lowest priority)

--- a/docs/contributing/TROUBLESHOOTING.md
+++ b/docs/contributing/TROUBLESHOOTING.md
@@ -459,11 +459,14 @@ git remote -v
 
 **Problem:** Settings not being applied
 
+**Note:** `gh-arc` resolves config files, CODEOWNERS, and other project files from the **git repository root**, not the current working directory. This means you can run `gh-arc` from any subdirectory and it will still find files at the repo root.
+
 **Debugging:**
 
 ```bash
-# Check config file location
-ls -la .arc.json
+# Check config file location (at repo root, not necessarily cwd)
+git rev-parse --show-toplevel  # Shows where gh-arc looks for config
+ls -la $(git rev-parse --show-toplevel)/.arc.json
 ls -la ~/.config/gh-arc/.arc.json
 
 # Check which config is loaded
@@ -473,7 +476,7 @@ ls -la ~/.config/gh-arc/.arc.json
 **Solution:**
 
 ```bash
-# Create config in current directory
+# Create config at repository root (not necessarily cwd)
 cat > .arc.json << EOF
 {
   "github": {

--- a/internal/codeowners/codeowners_test.go
+++ b/internal/codeowners/codeowners_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/serpro69/gh-arc/internal/git"
 )
 
 // Test CODEOWNERS file parsing
@@ -646,6 +648,52 @@ func TestHasCodeowners(t *testing.T) {
 			t.Error("HasCodeowners() = true, want false")
 		}
 	})
+}
+
+func TestParseCodeowners_FromSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatalf("Failed to create .git dir: %v", err)
+	}
+
+	githubDir := filepath.Join(tmpDir, ".github")
+	if err := os.MkdirAll(githubDir, 0o755); err != nil {
+		t.Fatalf("Failed to create .github dir: %v", err)
+	}
+	content := "*.go @golang-team\n"
+	if err := os.WriteFile(filepath.Join(githubDir, "CODEOWNERS"), []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to write CODEOWNERS: %v", err)
+	}
+
+	subDir := filepath.Join(tmpDir, "src", "pkg")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get cwd: %v", err)
+	}
+	os.Chdir(subDir)
+	defer os.Chdir(origDir)
+
+	// Resolve repo root from subdirectory (same pattern as diff/workflow.go)
+	repoRoot := "."
+	if root, err := git.FindRepositoryRoot(""); err == nil {
+		repoRoot = root
+	}
+
+	co, err := ParseCodeowners(repoRoot)
+	if err != nil {
+		t.Fatalf("ParseCodeowners failed from subdir: %v", err)
+	}
+	if len(co.Rules) != 1 {
+		t.Errorf("Expected 1 rule, got %d", len(co.Rules))
+	}
+	if co.Rules[0].Pattern != "*.go" {
+		t.Errorf("Expected pattern '*.go', got '%s'", co.Rules[0].Pattern)
+	}
 }
 
 // Benchmark tests

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -318,11 +318,19 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Validate template path if specified
+	// Validate template path if specified (resolve relative to repo root)
 	if c.Diff.TemplatePath != "" {
-		if _, err := os.Stat(c.Diff.TemplatePath); err != nil {
+		templatePath := c.Diff.TemplatePath
+		if !filepath.IsAbs(templatePath) {
+			repoRoot := "."
+			if root, err := git.FindRepositoryRoot(""); err == nil {
+				repoRoot = root
+			}
+			templatePath = filepath.Join(repoRoot, templatePath)
+		}
+		if _, err := os.Stat(templatePath); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("diff.templatePath does not exist: %q", c.Diff.TemplatePath)
+				return fmt.Errorf("diff.templatePath does not exist: %q (resolved to %q)", c.Diff.TemplatePath, templatePath)
 			}
 			return fmt.Errorf("diff.templatePath cannot be accessed: %w", err)
 		}
@@ -374,17 +382,26 @@ func (c *Config) Validate() error {
 // Returns (path/url, isURL, error)
 // If no local config exists, returns the GitHub raw URL to gh-arc's default config
 func (c *Config) GetMegaLinterConfigPath() (string, bool, error) {
+	repoRoot := "."
+	if root, err := git.FindRepositoryRoot(""); err == nil {
+		repoRoot = root
+	}
+
 	configPath := c.Lint.MegaLinter.Config
 
-	// Check if config file exists in project
+	// Check if config file exists in project (resolve relative to repo root)
 	if configPath != "" {
-		if _, err := os.Stat(configPath); err == nil {
-			return configPath, false, nil
+		absPath := configPath
+		if !filepath.IsAbs(configPath) {
+			absPath = filepath.Join(repoRoot, configPath)
+		}
+		if _, err := os.Stat(absPath); err == nil {
+			return absPath, false, nil
 		}
 	}
 
 	// Check for .mega-linter.yml in project root
-	defaultPath := ".mega-linter.yml"
+	defaultPath := filepath.Join(repoRoot, ".mega-linter.yml")
 	if _, err := os.Stat(defaultPath); err == nil {
 		return defaultPath, false, nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -631,6 +631,38 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidateTemplatePath_FromSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatalf("Failed to create .git dir: %v", err)
+	}
+
+	// Place template at repo root
+	templatePath := filepath.Join(tmpDir, "template.md")
+	if err := os.WriteFile(templatePath, []byte("# PR Template"), 0o644); err != nil {
+		t.Fatalf("Failed to write template: %v", err)
+	}
+
+	subDir := filepath.Join(tmpDir, "src", "pkg")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+	origDir, _ := os.Getwd()
+	os.Chdir(subDir)
+	defer os.Chdir(origDir)
+
+	cfg := &Config{
+		Land: LandConfig{DefaultMergeMethod: "squash", RequireApproval: "strict", RequireCI: "required"},
+		Lint: LintConfig{MegaLinter: MegaLinterConfig{Enabled: "auto"}},
+		Diff: DiffConfig{TemplatePath: "template.md"},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Expected no error for template at repo root from subdir, got: %v", err)
+	}
+}
+
 func TestGetMegaLinterConfigPath(t *testing.T) {
 	t.Run("returns configured path if exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -689,6 +721,86 @@ func TestGetMegaLinterConfigPath(t *testing.T) {
 		}
 		if path != defaultFile {
 			t.Errorf("Expected path '%s', got '%s'", defaultFile, path)
+		}
+	})
+
+	t.Run("finds configured path from subdirectory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		if err := os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+			t.Fatalf("Failed to create .git dir: %v", err)
+		}
+
+		configFile := filepath.Join(tmpDir, "custom-mega-linter.yml")
+		if err := os.WriteFile(configFile, []byte("test"), 0o644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		subDir := filepath.Join(tmpDir, "src", "pkg")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		origDir, _ := os.Getwd()
+		os.Chdir(subDir)
+		defer os.Chdir(origDir)
+
+		cfg := &Config{
+			Lint: LintConfig{
+				MegaLinter: MegaLinterConfig{
+					Config: "custom-mega-linter.yml",
+				},
+			},
+		}
+
+		path, isURL, err := cfg.GetMegaLinterConfigPath()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if isURL {
+			t.Error("Expected isURL to be false (local file)")
+		}
+		if path != configFile {
+			t.Errorf("Expected path '%s', got '%s'", configFile, path)
+		}
+	})
+
+	t.Run("finds default .mega-linter.yml from subdirectory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		if err := os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+			t.Fatalf("Failed to create .git dir: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(tmpDir, ".mega-linter.yml"), []byte("test"), 0o644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		subDir := filepath.Join(tmpDir, "src", "pkg")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		origDir, _ := os.Getwd()
+		os.Chdir(subDir)
+		defer os.Chdir(origDir)
+
+		cfg := &Config{
+			Lint: LintConfig{
+				MegaLinter: MegaLinterConfig{
+					Config: "nonexistent.yml",
+				},
+			},
+		}
+
+		path, isURL, err := cfg.GetMegaLinterConfigPath()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if isURL {
+			t.Error("Expected isURL to be false (local file)")
+		}
+		expected := filepath.Join(tmpDir, ".mega-linter.yml")
+		if path != expected {
+			t.Errorf("Expected path '%s', got '%s'", expected, path)
 		}
 	})
 

--- a/internal/diff/workflow.go
+++ b/internal/diff/workflow.go
@@ -485,8 +485,12 @@ func (w *DiffWorkflow) getReviewerSuggestions(ctx context.Context, currentBranch
 		currentUser = ""
 	}
 
-	// Parse CODEOWNERS file
-	co, err := codeowners.ParseCodeowners(".")
+	// Parse CODEOWNERS file from repo root so it's found from subdirectories
+	repoRoot := "."
+	if root, err := git.FindRepositoryRoot(""); err == nil {
+		repoRoot = root
+	}
+	co, err := codeowners.ParseCodeowners(repoRoot)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to parse CODEOWNERS file")
 	} else {


### PR DESCRIPTION
CODEOWNERS, MegaLinter config, and template path lookups used cwd-relative
paths, so running gh-arc from a subdirectory failed to find these files at
the repo root. Use git.FindRepositoryRoot to resolve the repo root first,
falling back to "." when outside a git repo — same pattern as the config
discovery fix in 5e62790.

## Test Plan
```bash
go test ./...
```